### PR TITLE
Named mastodon accounts

### DIFF
--- a/config/git_monitor.yaml.dist
+++ b/config/git_monitor.yaml.dist
@@ -37,27 +37,3 @@ git_monitor:
         # Note: backslashes need to be doubled
         #   defaults to "\\[(v[0-9]+\\.[0-9]+\\.[0-9]+)\\]"
         version_regex: "\\[(v[0-9]+\\.[0-9]+\\.[0-9]+)\\]"
-  # Configuration regarding the connection with Mastodon API
-  mastodon:
-    # [String] This will be the name of the bot
-    app_name: "Janitor"
-    # [String] Where to connecto to deliver the statuses
-    api_base_url: "https://mastodon.social"
-    # [String] Type of instance: 
-    #   "mastodon" for Mastodon
-    #   "pleroma" for Pleroma / Akkoma
-    #   "firefish" for Firefish / Calckey
-    instance_type: "pleroma"
-    # Credentials files to be generated
-    credentials:
-      # [String] Generated when creating the app. Contains Client ID and Client Secret
-      client_file: "client.secret"
-      # [String] Generated at first login. Contains the User Secret to be reused in further runs.
-      user_file: "user.secret"
-      # The User credentials. Used only during the first run.
-      # Should be Ok to delete the values once we have the "user.secret" generated
-      user:
-        # [String] email to be used to log in. For instance_type "firefish" it is ignored.
-        email: "bot+janitor@my-fancy.site"
-        # [String] Password to be used to log in. For instance_type "firefish" it is the Bearer token.
-        password: "SuperSecureP4ss"

--- a/config/mastodon.yaml.dist
+++ b/config/mastodon.yaml.dist
@@ -20,7 +20,7 @@ mastodon:
   # [Object] Mastodon account objects per name.
   #   The idea is that any Janitor module will refer to the name (key) of the object
   #   And then the related object will be loaded and used for publishing
-  per_name:
+  named_accounts:
     # [Object] The default Mastodon account object, basically used by all the application
     default:
       # [String] This will be the name of the bot

--- a/config/mastodon.yaml.dist
+++ b/config/mastodon.yaml.dist
@@ -6,17 +6,6 @@
 
 # Configuration regarding the connection with Mastodon API
 mastodon:
-  # Configuration regarding the Status Post itself
-  status_post:
-    # [Integer] Status max length
-    max_length: 500
-    # [String] Status Post content type: "text/plain" | "text/markdown" | "text/html" | "text/bbcode"
-    # Only vaild for Pleroma and Akkoma instances. Mastodon instances will ignore it
-    content_type: "text/markdown"
-    # [String] Status Post visibility: "direct" | "private" | "unlisted" | "public"
-    visibility: "public"
-    # [String] Username to mention for "direct" visibility 
-    username_to_dm: "@admin"
   # [Object] Mastodon account objects per name.
   #   The idea is that any Janitor module will refer to the name (key) of the object
   #   And then the related object will be loaded and used for publishing
@@ -45,6 +34,17 @@ mastodon:
           email: "bot+janitor@my-fancy.site"
           # [String] Password to be used to log in. For instance_type "firefish" it is the Bearer token.
           password: "SuperSecureP4ss"
+      # Configuration regarding the Status Post itself
+      status_post:
+        # [Integer] Status max length
+        max_length: 500
+        # [String] Status Post content type: "text/plain" | "text/markdown" | "text/html" | "text/bbcode"
+        # Only vaild for Pleroma and Akkoma instances. Mastodon instances will ignore it
+        content_type: "text/markdown"
+        # [String] Status Post visibility: "direct" | "private" | "unlisted" | "public"
+        visibility: "public"
+        # [String] Username to mention for "direct" visibility 
+        username_to_dm: "@admin"
     # [Object] The Mastodon account object used for the Git Monitoring updates.
     updates:
       # [String] This will be the name of the bot
@@ -69,3 +69,14 @@ mastodon:
           email: "bot+janitor@my-fancy.site"
           # [String] Password to be used to log in. For instance_type "firefish" it is the Bearer token.
           password: "SuperSecureP4ss"
+      # Configuration regarding the Status Post itself
+      status_post:
+        # [Integer] Status max length
+        max_length: 500
+        # [String] Status Post content type: "text/plain" | "text/markdown" | "text/html" | "text/bbcode"
+        # Only vaild for Pleroma and Akkoma instances. Mastodon instances will ignore it
+        content_type: "text/markdown"
+        # [String] Status Post visibility: "direct" | "private" | "unlisted" | "public"
+        visibility: "public"
+        # [String] Username to mention for "direct" visibility 
+        username_to_dm: "@admin"

--- a/config/mastodon.yaml.dist
+++ b/config/mastodon.yaml.dist
@@ -6,28 +6,6 @@
 
 # Configuration regarding the connection with Mastodon API
 mastodon:
-   # [String] This will be the name of the bot
-  app_name: "Janitor"
-  # [String] Where to connecto to deliver the statuses
-  api_base_url: "https://mastodon.social"
-  # [String] Type of instance: 
-  #   "mastodon" for Mastodon
-  #   "pleroma" for Pleroma / Akkoma
-  #   "firefish" for Firefish / Calckey
-  instance_type: "pleroma"
-  # Credentials files to be generated
-  credentials:
-    # [String] Generated when creating the app. Contains Client ID and Client Secret
-    client_file: "client.secret"
-    # [String] Generated at first login. Contains the User Secret to be reused in further runs.
-    user_file: "user.secret"
-    # The User credentials. Used only during the first run.
-    # Should be Ok to delete the values once we have the "user.secret" generated
-    user:
-      # [String] email to be used to log in. For instance_type "firefish" it is ignored.
-      email: "bot+janitor@my-fancy.site"
-      # [String] Password to be used to log in. For instance_type "firefish" it is the Bearer token.
-      password: "SuperSecureP4ss"
   # Configuration regarding the Status Post itself
   status_post:
     # [Integer] Status max length
@@ -39,3 +17,55 @@ mastodon:
     visibility: "public"
     # [String] Username to mention for "direct" visibility 
     username_to_dm: "@admin"
+  # [Object] Mastodon account objects per name.
+  #   The idea is that any Janitor module will refer to the name (key) of the object
+  #   And then the related object will be loaded and used for publishing
+  per_name:
+    # [Object] The default Mastodon account object, basically used by all the application
+    default:
+      # [String] This will be the name of the bot
+      app_name: "Janitor"
+      # [String] Where to connecto to deliver the statuses
+      api_base_url: "https://mastodon.social"
+      # [String] Type of instance: 
+      #   "mastodon" for Mastodon
+      #   "pleroma" for Pleroma / Akkoma
+      #   "firefish" for Firefish / Calckey
+      instance_type: "pleroma"
+      # Credentials files to be generated
+      credentials:
+        # [String] Generated when creating the app. Contains Client ID and Client Secret
+        client_file: "client.secret"
+        # [String] Generated at first login. Contains the User Secret to be reused in further runs.
+        user_file: "user.secret"
+        # The User credentials. Used only during the first run.
+        # Should be Ok to delete the values once we have the "user.secret" generated
+        user:
+          # [String] email to be used to log in. For instance_type "firefish" it is ignored.
+          email: "bot+janitor@my-fancy.site"
+          # [String] Password to be used to log in. For instance_type "firefish" it is the Bearer token.
+          password: "SuperSecureP4ss"
+    # [Object] The Mastodon account object used for the Git Monitoring updates.
+    updates:
+      # [String] This will be the name of the bot
+      app_name: "Janitor"
+      # [String] Where to connecto to deliver the statuses
+      api_base_url: "https://mastodon.social"
+      # [String] Type of instance: 
+      #   "mastodon" for Mastodon
+      #   "pleroma" for Pleroma / Akkoma
+      #   "firefish" for Firefish / Calckey
+      instance_type: "pleroma"
+      # Credentials files to be generated
+      credentials:
+        # [String] Generated when creating the app. Contains Client ID and Client Secret
+        client_file: "client.secret"
+        # [String] Generated at first login. Contains the User Secret to be reused in further runs.
+        user_file: "user.secret"
+        # The User credentials. Used only during the first run.
+        # Should be Ok to delete the values once we have the "user.secret" generated
+        user:
+          # [String] email to be used to log in. For instance_type "firefish" it is ignored.
+          email: "bot+janitor@my-fancy.site"
+          # [String] Password to be used to log in. For instance_type "firefish" it is the Bearer token.
+          password: "SuperSecureP4ss"

--- a/docs/git_monitor.md
+++ b/docs/git_monitor.md
@@ -7,7 +7,8 @@ Janitor can monitor one or more Git repositories and publish a post to a Mastodo
 In the `git_monitor.yaml` config file there is the `git_monitor` section with all the possible parameters. There are 3 main ones:
 - `git_monitor.file` identifies which file will handle the state for the last known version per repository
 - `git_monitor.repositories` is a list of objects where each one represents all the parameters for a repository to monitor. Below we'll go deeper on this.
-- `git_monitor.mastodon` is an object very similar to the main `mastodon` one that contains the Mastodon instance parameters and credentials for the account that will be used to publish the updates. This means that the there can be a different user responsible for the change updates, different from the common Janitor one.
+
+In the `mastodon.yaml` config file there is one more *named account* set up called `updates`. The structure is identical to the `default` one, and contains the Mastodon instance parameters and credentials for the account that will be used to publish the updates. This means that the there can be a different account responsible for the change updates, different from the default Janitor one.
 
 ### Repository configuration
 

--- a/janitor/lib/mastodon_helper.py
+++ b/janitor/lib/mastodon_helper.py
@@ -31,7 +31,9 @@ class MastodonHelper:
             logger.warn(
                 "Getting instance without explicit connection params. Auto-discovering!"
             )
-            connection_params = MastodonConnectionParams.from_dict(config.get("mastodon"))
+            connection_params = MastodonConnectionParams.from_dict(
+                config.get("mastodon.per_name.default")
+            )
 
         instance_type = MastodonHelper.valid_or_raise(connection_params.instance_type)
         user_file = connection_params.credentials.user_file

--- a/janitor/lib/mastodon_helper.py
+++ b/janitor/lib/mastodon_helper.py
@@ -32,7 +32,7 @@ class MastodonHelper:
                 "Getting instance without explicit connection params. Auto-discovering!"
             )
             connection_params = MastodonConnectionParams.from_dict(
-                config.get("mastodon.per_name.default")
+                config.get("mastodon.named_accounts.default")
             )
 
         instance_type = MastodonHelper.valid_or_raise(connection_params.instance_type)

--- a/janitor/lib/mastodon_helper.py
+++ b/janitor/lib/mastodon_helper.py
@@ -22,18 +22,10 @@ class MastodonHelper:
     @staticmethod
     def get_instance(
         config: Config,
-        connection_params: MastodonConnectionParams = None,
+        connection_params: MastodonConnectionParams,
         base_path: str = None
     ) -> Mastodon:
         logger = logging.getLogger(config.get("logger.name"))
-
-        if connection_params is None:
-            logger.warn(
-                "Getting instance without explicit connection params. Auto-discovering!"
-            )
-            connection_params = MastodonConnectionParams.from_dict(
-                config.get("mastodon.named_accounts.default")
-            )
 
         instance_type = MastodonHelper.valid_or_raise(connection_params.instance_type)
         user_file = connection_params.credentials.user_file

--- a/janitor/lib/publisher.py
+++ b/janitor/lib/publisher.py
@@ -46,7 +46,7 @@ class Publisher:
             #             self._logger.info("Could not publish %s", item["url"])
             instance_type = MastodonHelper.valid_or_raise(
                 self._config.get(
-                    "mastodon.per_name.default.instance_type", MastodonHelper.TYPE_MASTODON
+                    "mastodon.named_accounts.default.instance_type", MastodonHelper.TYPE_MASTODON
                 )
             )
             self._logger.debug(f"Instance type is valid: {instance_type}")

--- a/janitor/lib/publisher.py
+++ b/janitor/lib/publisher.py
@@ -26,9 +26,9 @@ class Publisher:
         self._config = config
         self._logger = logging.getLogger(config.get("logger.name"))
         self._queue = Queue(config, base_path=base_path)
-        self._formatter = Formatter(config)
         self._mastodon = mastodon
         self._connection_params = connection_params
+        self._formatter = Formatter(config, connection_params.status_params)
 
     def publish_one(self, item: QueueItem) -> dict:
         # Translate the Message to StatusPost

--- a/janitor/lib/publisher.py
+++ b/janitor/lib/publisher.py
@@ -46,7 +46,8 @@ class Publisher:
             #             self._logger.info("Could not publish %s", item["url"])
             instance_type = MastodonHelper.valid_or_raise(
                 self._config.get(
-                    "mastodon.named_accounts.default.instance_type", MastodonHelper.TYPE_MASTODON
+                    "mastodon.named_accounts.default.instance_type",
+                    MastodonHelper.TYPE_MASTODON
                 )
             )
             self._logger.debug(f"Instance type is valid: {instance_type}")

--- a/janitor/lib/publisher.py
+++ b/janitor/lib/publisher.py
@@ -45,7 +45,9 @@ class Publisher:
             #         else:
             #             self._logger.info("Could not publish %s", item["url"])
             instance_type = MastodonHelper.valid_or_raise(
-                self._config.get("mastodon.instance_type", MastodonHelper.TYPE_MASTODON)
+                self._config.get(
+                    "mastodon.per_name.default.instance_type", MastodonHelper.TYPE_MASTODON
+                )
             )
             self._logger.debug(f"Instance type is valid: {instance_type}")
 

--- a/janitor/objects/mastodon_connection_params.py
+++ b/janitor/objects/mastodon_connection_params.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from janitor.objects.status_post import StatusPostContentType, StatusPostVisibility
 
 
 class MastodonConnectionParams():
@@ -9,25 +10,38 @@ class MastodonConnectionParams():
 
     VALID_TYPES = [TYPE_MASTODON, TYPE_PLEROMA, TYPE_FIREFISH]
 
+    DEFAULT_INSTANCE_TYPE = TYPE_MASTODON
+
     instance_type: str
     api_base_url: str
     credentials: MastodonCredentials
+    status_params: MastodonStatusParams
 
     def __init__(
         self,
         instance_type: str = None,
         api_base_url: str = None,
-        credentials: MastodonCredentials = None
+        credentials: MastodonCredentials = None,
+        status_params: MastodonStatusParams = None
     ) -> None:
-        self.instance_type = instance_type if instance_type is not None else self.TYPE_MASTODON
+        self.instance_type = instance_type\
+            if instance_type is not None else self.DEFAULT_INSTANCE_TYPE
         self.api_base_url = api_base_url
         self.credentials = credentials
+        # Status Params has always to come, even with the default values
+        if status_params is None:
+            self.status_params = MastodonStatusParams()
+        else:
+            self.status_params = status_params
 
     def to_dict(self) -> dict:
         return {
             "instance_type": self.instance_type,
             "api_base_url": self.api_base_url,
             "credentials": self.credentials.to_dict()
+            if isinstance(self.credentials, MastodonCredentials) else None,
+            "status_params": self.status_params.to_dict()
+            if isinstance(self.status_params, MastodonStatusParams) else None
         }
 
     @staticmethod
@@ -38,11 +52,17 @@ class MastodonConnectionParams():
             api_base_url=connection_params_dict["api_base_url"]
             if "api_base_url" in connection_params_dict else None,
             credentials=MastodonCredentials.from_dict(connection_params_dict["credentials"])
-            if "credentials" in connection_params_dict else None
+            if "credentials" in connection_params_dict else None,
+            status_params=MastodonStatusParams.from_dict(
+                connection_params_dict["status_params"]
+            ) if "status_params" in connection_params_dict else None
         )
 
 
 class MastodonCredentials():
+
+    DEFAULT_USER_FILE = "user.secret"
+    DEFAULT_CLIENT_FILE = "client.secret"
 
     user_file: str
     client_file: str
@@ -54,15 +74,17 @@ class MastodonCredentials():
         client_file: str = None,
         user: MastodonUser = None
     ) -> None:
-        self.user_file = user_file
-        self.client_file = client_file
+        self.user_file = user_file\
+            if user_file is not None else self.DEFAULT_USER_FILE
+        self.client_file = client_file\
+            if client_file is not None else self.DEFAULT_CLIENT_FILE
         self.user = user
 
     def to_dict(self) -> dict:
         return {
             "user_file": self.user_file,
             "client_file": self.client_file,
-            "user": self.user.to_dict()
+            "user": self.user.to_dict() if isinstance(self.user, MastodonUser) else None
         }
 
     @staticmethod
@@ -94,4 +116,57 @@ class MastodonUser():
         return MastodonUser(
             email=credentials_dict["email"] if "email" in credentials_dict else None,
             password=credentials_dict["password"] if "password" in credentials_dict else None
+        )
+
+
+class MastodonStatusParams():
+
+    DEFAULT_MAX_LENGTH = 500
+    DEFAULT_CONTENT_TYPE = StatusPostContentType.PLAIN
+    DEFAULT_VISIBILITY = StatusPostVisibility.PUBLIC
+
+    max_length: int
+    content_type: StatusPostContentType
+    visibility: StatusPostVisibility
+    username_to_dm: str
+
+    def __init__(
+        self,
+        max_length: int = None,
+        content_type: StatusPostContentType = None,
+        visibility: StatusPostVisibility = None,
+        username_to_dm: str = None
+    ) -> None:
+        self.max_length = max_length if max_length is not None else self.DEFAULT_MAX_LENGTH
+        self.content_type = StatusPostContentType.valid_or_raise(content_type)\
+            if content_type is not None else self.DEFAULT_CONTENT_TYPE
+        if visibility is None:
+            self.visibility = self.DEFAULT_VISIBILITY
+        else:
+            self.visibility = StatusPostVisibility.valid_or_raise(visibility)
+            if self.visibility == StatusPostVisibility.DIRECT\
+               and username_to_dm is None:
+                raise ValueError(
+                    "The field username_to_dm is mandatory if visibility" +
+                    f" is {StatusPostVisibility.DIRECT}"
+                )
+        self.username_to_dm = username_to_dm
+
+    def to_dict(self) -> dict:
+        return {
+            "max_length": self.max_length,
+            "content_type": self.content_type,
+            "visibility": self.visibility,
+            "username_to_dm": self.username_to_dm
+        }
+
+    @staticmethod
+    def from_dict(status_params: dict) -> MastodonStatusParams:
+        return MastodonStatusParams(
+            max_length=status_params["max_length"] if "max_length" in status_params else None,
+            content_type=status_params["content_type"]
+            if "content_type" in status_params else None,
+            visibility=status_params["visibility"] if "visibility" in status_params else None,
+            username_to_dm=status_params["username_to_dm"]
+            if "username_to_dm" in status_params else None
         )

--- a/janitor/objects/mastodon_connection_params.py
+++ b/janitor/objects/mastodon_connection_params.py
@@ -12,6 +12,7 @@ class MastodonConnectionParams():
 
     DEFAULT_INSTANCE_TYPE = TYPE_MASTODON
 
+    app_name: str
     instance_type: str
     api_base_url: str
     credentials: MastodonCredentials
@@ -19,11 +20,13 @@ class MastodonConnectionParams():
 
     def __init__(
         self,
+        app_name: str = None,
         instance_type: str = None,
         api_base_url: str = None,
         credentials: MastodonCredentials = None,
         status_params: MastodonStatusParams = None
     ) -> None:
+        self.app_name = app_name
         self.instance_type = instance_type\
             if instance_type is not None else self.DEFAULT_INSTANCE_TYPE
         self.api_base_url = api_base_url
@@ -36,6 +39,7 @@ class MastodonConnectionParams():
 
     def to_dict(self) -> dict:
         return {
+            "app_name": self.app_name,
             "instance_type": self.instance_type,
             "api_base_url": self.api_base_url,
             "credentials": self.credentials.to_dict()
@@ -47,6 +51,8 @@ class MastodonConnectionParams():
     @staticmethod
     def from_dict(connection_params_dict: dict) -> MastodonConnectionParams:
         return MastodonConnectionParams(
+            app_name=connection_params_dict["app_name"]
+            if "app_name" in connection_params_dict else None,
             instance_type=connection_params_dict["instance_type"]
             if "instance_type" in connection_params_dict else None,
             api_base_url=connection_params_dict["api_base_url"]

--- a/janitor/runners/create_app.py
+++ b/janitor/runners/create_app.py
@@ -19,11 +19,11 @@ class CreateApp(RunnerProtocol):
     def run(self):
         self._logger.info("Run Create App")
         MastodonHelper.create_app(
-            self._config.get("mastodon.per_name.default.instance_type"),
-            self._config.get("mastodon.per_name.default.app_name"),
-            api_base_url=self._config.get("mastodon.per_name.default.api_base_url"),
+            self._config.get("mastodon.named_accounts.default.instance_type"),
+            self._config.get("mastodon.named_accounts.default.app_name"),
+            api_base_url=self._config.get("mastodon.named_accounts.default.api_base_url"),
             to_file=os.path.join(
-                ROOT_DIR, self._config.get("mastodon.per_name.default.credentials.client_file")
+                ROOT_DIR, self._config.get("mastodon.named_accounts.default.credentials.client_file")
             )
         )
         self._logger.info("Finished Create App")

--- a/janitor/runners/create_app.py
+++ b/janitor/runners/create_app.py
@@ -23,7 +23,8 @@ class CreateApp(RunnerProtocol):
             self._config.get("mastodon.named_accounts.default.app_name"),
             api_base_url=self._config.get("mastodon.named_accounts.default.api_base_url"),
             to_file=os.path.join(
-                ROOT_DIR, self._config.get("mastodon.named_accounts.default.credentials.client_file")
+                ROOT_DIR,
+                self._config.get("mastodon.named_accounts.default.credentials.client_file")
             )
         )
         self._logger.info("Finished Create App")

--- a/janitor/runners/create_app.py
+++ b/janitor/runners/create_app.py
@@ -19,11 +19,11 @@ class CreateApp(RunnerProtocol):
     def run(self):
         self._logger.info("Run Create App")
         MastodonHelper.create_app(
-            self._config.get("mastodon.instance_type"),
-            self._config.get("mastodon.app_name"),
-            api_base_url=self._config.get("mastodon.api_base_url"),
+            self._config.get("mastodon.per_name.default.instance_type"),
+            self._config.get("mastodon.per_name.default.app_name"),
+            api_base_url=self._config.get("mastodon.per_name.default.api_base_url"),
             to_file=os.path.join(
-                ROOT_DIR, self._config.get("mastodon.credentials.client_file")
+                ROOT_DIR, self._config.get("mastodon.per_name.default.credentials.client_file")
             )
         )
         self._logger.info("Finished Create App")

--- a/janitor/runners/git_changes.py
+++ b/janitor/runners/git_changes.py
@@ -83,7 +83,7 @@ class GitChanges(RunnerProtocol):
         #   which only publishes updates.
         #   This means to instantiate a different Mastodon helper
         conn_params = MastodonConnectionParams.from_dict(
-            self._config.get("git_monitor.mastodon")
+            self._config.get("mastodon.named_accounts.updates")
         )
         client_file = os.path.join(ROOT_DIR, conn_params.credentials.client_file)
         # If the client_file does not exist we need to trigger the
@@ -91,7 +91,7 @@ class GitChanges(RunnerProtocol):
         if not os.path.exists(client_file):
             MastodonHelper.create_app(
                 instance_type=conn_params.instance_type,
-                client_name=self._config.get("git_monitor.mastodon.app_name"),
+                client_name=conn_params.app_name,
                 api_base_url=conn_params.api_base_url,
                 to_file=client_file
             )
@@ -106,9 +106,14 @@ class GitChanges(RunnerProtocol):
     def _publish_notification(self, message: Message):
         # This is the notification that we publish to
         #   the usual account, just to say who the action went.
+        conn_params = MastodonConnectionParams.from_dict(
+            self._config.get("mastodon.named_accounts.default")
+        )
 
         # Get the instance. Everything is by default
-        mastodon_instance = MastodonHelper.get_instance(self._config)
+        mastodon_instance = MastodonHelper.get_instance(
+            config=self._config, connection_params=conn_params
+        )
         # Now publish the message
         _ = Publisher(self._config, mastodon_instance, base_path=ROOT_DIR)\
             .publish_one(QueueItem(message))

--- a/janitor/runners/git_changes.py
+++ b/janitor/runners/git_changes.py
@@ -100,8 +100,12 @@ class GitChanges(RunnerProtocol):
             config=self._config, connection_params=conn_params
         )
         # Now publish the message
-        _ = Publisher(self._config, mastodon_instance, base_path=ROOT_DIR)\
-            .publish_one(QueueItem(message))
+        _ = Publisher(
+            config=self._config,
+            mastodon=mastodon_instance,
+            connection_params=conn_params,
+            base_path=ROOT_DIR
+        ).publish_one(QueueItem(message))
 
     def _publish_notification(self, message: Message):
         # This is the notification that we publish to
@@ -115,5 +119,9 @@ class GitChanges(RunnerProtocol):
             config=self._config, connection_params=conn_params
         )
         # Now publish the message
-        _ = Publisher(self._config, mastodon_instance, base_path=ROOT_DIR)\
-            .publish_one(QueueItem(message))
+        _ = Publisher(
+            config=self._config,
+            mastodon=mastodon_instance,
+            connection_params=conn_params,
+            base_path=ROOT_DIR
+        ).publish_one(QueueItem(message))

--- a/janitor/runners/listen.py
+++ b/janitor/runners/listen.py
@@ -96,7 +96,12 @@ class ListenSysInfo(Resource):
         mastodon = MastodonHelper.get_instance(
             config=self._config, connection_params=conn_params, base_path=ROOT_DIR
         )
-        publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
+        publisher = Publisher(
+            config=self._config,
+            mastodon=mastodon,
+            connection_params=conn_params,
+            base_path=ROOT_DIR
+        )
         self._logger.info("Publishing one message")
         publisher.publish_one(QueueItem(message))
 
@@ -189,7 +194,12 @@ class ListenMessage(Resource):
         mastodon = MastodonHelper.get_instance(
             config=self._config, connection_params=conn_params, base_path=ROOT_DIR
         )
-        publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
+        publisher = Publisher(
+            config=self._config,
+            mastodon=mastodon,
+            connection_params=conn_params,
+            base_path=ROOT_DIR
+        )
         self._logger.info("Publishing one message")
         publisher.publish_one(QueueItem(message))
 

--- a/janitor/runners/listen.py
+++ b/janitor/runners/listen.py
@@ -3,6 +3,7 @@ from janitor.lib.system_info import SystemInfo
 from janitor.lib.system_info_templater import SystemInfoTemplater
 from janitor.lib.publisher import Publisher
 from janitor.lib.mastodon_helper import MastodonHelper
+from janitor.objects.mastodon_connection_params import MastodonConnectionParams
 from janitor.objects.queue_item import QueueItem
 from janitor.objects.message import Message, MessageType
 from janitor.runners.runner_protocol import RunnerProtocol
@@ -89,7 +90,12 @@ class ListenSysInfo(Resource):
         message = SystemInfoTemplater(self._config).process_report(sys_data)
 
         # Publish the queue
-        mastodon = MastodonHelper.get_instance(self._config, base_path=ROOT_DIR)
+        conn_params = MastodonConnectionParams.from_dict(
+            self._config.get("mastodon.named_accounts.default")
+        )
+        mastodon = MastodonHelper.get_instance(
+            config=self._config, connection_params=conn_params, base_path=ROOT_DIR
+        )
         publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
         self._logger.info("Publishing one message")
         publisher.publish_one(QueueItem(message))
@@ -177,7 +183,12 @@ class ListenMessage(Resource):
             message = Message(summary=f"{icon} {hostname}:\n\n{summary}", text=f"{text}")
 
         # Publish the queue
-        mastodon = MastodonHelper.get_instance(self._config, base_path=ROOT_DIR)
+        conn_params = MastodonConnectionParams.from_dict(
+            self._config.get("mastodon.named_accounts.default")
+        )
+        mastodon = MastodonHelper.get_instance(
+            config=self._config, connection_params=conn_params, base_path=ROOT_DIR
+        )
         publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
         self._logger.info("Publishing one message")
         publisher.publish_one(QueueItem(message))

--- a/janitor/runners/publish_queue.py
+++ b/janitor/runners/publish_queue.py
@@ -1,5 +1,6 @@
 from pyxavi.config import Config
 from janitor.lib.mastodon_helper import MastodonHelper
+from janitor.objects.mastodon_connection_params import MastodonConnectionParams
 from janitor.lib.publisher import Publisher
 from janitor.runners.runner_protocol import RunnerProtocol
 from definitions import ROOT_DIR
@@ -21,7 +22,12 @@ class PublishQueue(RunnerProtocol):
         '''
         try:
             # All actions are done under a Mastodon API instance
-            mastodon = MastodonHelper.get_instance(self._config, base_path=ROOT_DIR)
+            conn_params = MastodonConnectionParams.from_dict(
+                self._config.get("mastodon.named_accounts.default")
+            )
+            mastodon = MastodonHelper.get_instance(
+                config=self._config, connection_params=conn_params, base_path=ROOT_DIR
+            )
 
             # Read from the queue the toots to publish
             # and publishes all of them

--- a/janitor/runners/publish_queue.py
+++ b/janitor/runners/publish_queue.py
@@ -31,7 +31,12 @@ class PublishQueue(RunnerProtocol):
 
             # Read from the queue the toots to publish
             # and publishes all of them
-            publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
+            publisher = Publisher(
+                config=self._config,
+                mastodon=mastodon,
+                connection_params=conn_params,
+                base_path=ROOT_DIR
+            )
             self._logger.info("Publishing the whole queue")
             publisher.publish_all_from_queue()
         except Exception as e:

--- a/janitor/runners/publish_test.py
+++ b/janitor/runners/publish_test.py
@@ -1,5 +1,6 @@
 from pyxavi.config import Config
 from janitor.lib.mastodon_helper import MastodonHelper
+from janitor.objects.mastodon_connection_params import MastodonConnectionParams
 from janitor.lib.publisher import Publisher
 from janitor.objects.message import Message
 from janitor.objects.queue_item import QueueItem
@@ -23,9 +24,13 @@ class PublishTest(RunnerProtocol):
         '''
         try:
             # All actions are done under a Mastodon API instance
-            instance_type = self._config.get("mastodon.instance_type")
-            self._logger.info(f"Defined instance type: {instance_type}")
-            mastodon = MastodonHelper.get_instance(self._config, base_path=ROOT_DIR)
+            conn_params = MastodonConnectionParams.from_dict(
+                self._config.get("mastodon.named_accounts.default")
+            )
+            self._logger.info(f"Defined instance type: {conn_params.instance_type}")
+            mastodon = MastodonHelper.get_instance(
+                config=self._config, connection_params=conn_params, base_path=ROOT_DIR
+            )
             wrapper = type(mastodon)
             self._logger.info(f"Loaded wrapper: {wrapper}")
 

--- a/janitor/runners/publish_test.py
+++ b/janitor/runners/publish_test.py
@@ -35,7 +35,12 @@ class PublishTest(RunnerProtocol):
             self._logger.info(f"Loaded wrapper: {wrapper}")
 
             # Prepare the Publisher
-            publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
+            publisher = Publisher(
+                config=self._config,
+                mastodon=mastodon,
+                connection_params=conn_params,
+                base_path=ROOT_DIR
+            )
 
             # Prepare a test message
             self._logger.info("Preparing a test message")

--- a/janitor/runners/run_local.py
+++ b/janitor/runners/run_local.py
@@ -42,7 +42,12 @@ class RunLocal(RunnerProtocol):
         mastodon = MastodonHelper.get_instance(
             config=self._config, connection_params=conn_params, base_path=ROOT_DIR
         )
-        publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
+        publisher = Publisher(
+            config=self._config,
+            mastodon=mastodon,
+            connection_params=conn_params,
+            base_path=ROOT_DIR
+        )
         self._logger.info("Publishing the whole queue")
         queue_item = QueueItem(message)
         publisher.publish_one(queue_item)

--- a/janitor/runners/run_local.py
+++ b/janitor/runners/run_local.py
@@ -3,6 +3,7 @@ from janitor.lib.system_info import SystemInfo
 from janitor.lib.system_info_templater import SystemInfoTemplater
 from janitor.lib.publisher import Publisher
 from janitor.lib.mastodon_helper import MastodonHelper
+from janitor.objects.mastodon_connection_params import MastodonConnectionParams
 from janitor.objects.queue_item import QueueItem
 from janitor.runners.runner_protocol import RunnerProtocol
 from definitions import ROOT_DIR
@@ -35,7 +36,12 @@ class RunLocal(RunnerProtocol):
         message = SystemInfoTemplater(self._config).process_report(sys_data)
 
         # Publish the queue
-        mastodon = MastodonHelper.get_instance(self._config, base_path=ROOT_DIR)
+        conn_params = MastodonConnectionParams.from_dict(
+            self._config.get("mastodon.named_accounts.default")
+        )
+        mastodon = MastodonHelper.get_instance(
+            config=self._config, connection_params=conn_params, base_path=ROOT_DIR
+        )
         publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
         self._logger.info("Publishing the whole queue")
         queue_item = QueueItem(message)

--- a/janitor/runners/update_ddns.py
+++ b/janitor/runners/update_ddns.py
@@ -1,5 +1,6 @@
 from pyxavi.config import Config
 from janitor.lib.mastodon_helper import MastodonHelper
+from janitor.objects.mastodon_connection_params import MastodonConnectionParams
 from janitor.lib.publisher import Publisher
 from janitor.objects.message import Message
 from janitor.objects.queue_item import QueueItem
@@ -24,7 +25,12 @@ class UpdateDdns(RunnerProtocol):
 
     def _send_mastodon_message(self, text: str) -> None:
         self._logger.info("Initializing Mastodon tooling")
-        mastodon = MastodonHelper.get_instance(self._config, base_path=ROOT_DIR)
+        conn_params = MastodonConnectionParams.from_dict(
+            self._config.get("mastodon.named_accounts.default")
+        )
+        mastodon = MastodonHelper.get_instance(
+            config=self._config, connection_params=conn_params, base_path=ROOT_DIR
+        )
         publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
         queue_item = QueueItem(message=Message(text=text))
         self._logger.info("Publishing Mastodon message")

--- a/janitor/runners/update_ddns.py
+++ b/janitor/runners/update_ddns.py
@@ -31,7 +31,12 @@ class UpdateDdns(RunnerProtocol):
         mastodon = MastodonHelper.get_instance(
             config=self._config, connection_params=conn_params, base_path=ROOT_DIR
         )
-        publisher = Publisher(self._config, mastodon, base_path=ROOT_DIR)
+        publisher = Publisher(
+            config=self._config,
+            mastodon=mastodon,
+            connection_params=conn_params,
+            base_path=ROOT_DIR
+        )
         queue_item = QueueItem(message=Message(text=text))
         self._logger.info("Publishing Mastodon message")
         _ = publisher.publish_one(queue_item)

--- a/pre-CHANGELOG.md
+++ b/pre-CHANGELOG.md
@@ -12,3 +12,4 @@
 - README and documentation has been iterated
 - The *config* file has been sliced into several *config* files per module
 - The `validate_config` now is improved and considers all config files
+- Now all mastodon publishing accounts are registered inside the `mastodon.yaml` config file, each under a name, to easily be referenced from other Janitor modules.

--- a/scripts/migrate_config_0_5_0.py
+++ b/scripts/migrate_config_0_5_0.py
@@ -3,11 +3,14 @@ from definitions import ROOT_DIR, CONFIG_DIR
 from pyxavi.terminal_color import TerminalColor
 from pyxavi.storage import Storage
 from string import Template
+import copy
 
 DEFAULT_CONFIG_FILE_NAME = "config.yaml"
 REQUEST_CONFIG_NAME = "Origin config file [$path] (press ENTER to accept default):"
+DEBUG = False
 
 # This represents old location to new location
+# When some internals are moved, the siblings need to be pointed individually
 MAP_OLD_TO_NEW = {
     "app.service": ("main.yaml", "app.service"),
     "app.run_control": ("main.yaml", "app.run_control"),
@@ -26,8 +29,25 @@ MAP_OLD_TO_NEW = {
         "sysinfo.yaml", "system_info.formatting.human_readable_exceptions"
     ),
     "directnic_ddns": ("directnic_ddns.yaml", "directnic_ddns"),
-    "git_monitor": ("git_monitor.yaml", "git_monitor"),
-    "mastodon": ("mastodon.yaml", "mastodon"),
+    "git_monitor.file": ("git_monitor.yaml", "git_monitor.file"),
+    "git_monitor.repositories": ("git_monitor.yaml", "git_monitor.repositories"),
+    # The next mastodon ones is because we want to do a rename,
+    #   from status_post to status_params
+    "mastodon.app_name": ("mastodon.yaml", "mastodon.named_accounts.default.app_name"),
+    "mastodon.api_base_url": ("mastodon.yaml", "mastodon.named_accounts.default.api_base_url"),
+    "mastodon.instance_type": (
+        "mastodon.yaml", "mastodon.named_accounts.default.instance_type"
+    ),
+    "mastodon.credentials": ("mastodon.yaml", "mastodon.named_accounts.default.credentials"),
+    # Now we place the mastodon updates account data
+    #   to the mastodon config as a different account.
+    "git_monitor.mastodon": ("mastodon.yaml", "mastodon.named_accounts.updates"),
+    # and this is a copy, from default to the updates named_account, also changing the name
+    # We even have to duplicate it into 2 places
+    "mastodon.status_post": [
+        ("mastodon.yaml", "mastodon.named_accounts.updates.status_params"),
+        ("mastodon.yaml", "mastodon.named_accounts.default.status_params")
+    ]
 }
 
 
@@ -39,72 +59,147 @@ def run():
         )
     )
     if config_path == "":
+        log("Using suggested default config path and name")
         config_path = os.path.join(ROOT_DIR, DEFAULT_CONFIG_FILE_NAME)
+    else:
+        log(f"Using user input config: [{config_path}]")
 
     # Load the origin config file. Will fail otherwise.
     origin_file = Storage(config_path)
+    log("Original config file loaded")
 
     try:
         # Ensure that the target CONFIG_DIR exists, otherwise create it.
         if not os.path.exists(CONFIG_DIR):
             os.makedirs(CONFIG_DIR)
-            print(f"Created the directory [{CONFIG_DIR}]")
+            log(f"Created the directory [{CONFIG_DIR}]")
 
         # Create the target files and keep them in memory
         target_storage = {}
-        for origin_key, pair in MAP_OLD_TO_NEW.items():
-            target_file, target_key = pair
-            target_path = os.path.join(CONFIG_DIR, target_file)
-
-            # Only in case that we did not already instantiate the storage
-            if target_file not in target_storage:
-                # Ensure that the target file does not already exist
-                if os.path.exists(target_path):
-                    raise RuntimeError(
-                        f"The target config file [{target_path}] already exists. Should not."
-                    )
-
-                # Instantiate the storage, which already creates the file
-                target_storage[target_file] = Storage(filename=target_path)
-
-            # Bring the parameters from the old config
-            origin_value = origin_file.get(origin_key)
-
-            # Could be that the target's parent objects were already created.
-            #   Check if they exist to avoid overwritting anything.
-            #   Still, if they don't exists, just go on creating the objects.
-            if target_key.find(".") > 0:
-                target_key_pieces = target_key.split(".")
+        for origin_key, pairs in MAP_OLD_TO_NEW.items():
+            if isinstance(pairs, list):
+                log(f"We have to copy {origin_key} into {len(pairs)} destinations!")
             else:
-                target_key_pieces = [target_key]
-            parents = ""
-            for piece in target_key_pieces:
-                # Get current target value
-                current_target_value = target_storage[target_file].get(
-                    f"{parents}{piece}", None
+                log(
+                    f"We have to copy {origin_key} into only one destination. " +
+                    "Emulating a list of 1 element"
                 )
+                pairs = [pairs]
+            pair_iteration = 0
+            for pair in pairs:
+                pair_iteration += 1
+                log(f"Starting iteration {pair_iteration}")
+                target_file, target_key = pair
+                log(f"Processing {origin_key} => {target_file}:{target_key}")
+                target_path = os.path.join(CONFIG_DIR, target_file)
+                log(f"Real target file name and path is [{target_path}]")
 
-                # So if this object does not exist we have to create something.
-                if current_target_value is None:
-                    # Wait, are we actually the final object, suposed to hold ve target value?
-                    if piece == target_key_pieces[-1]:
-                        # Ok, so this is it, let's set the original value here
-                        target_storage[target_file].set(f"{parents}{piece}", origin_value)
+                # Only in case that we did not already instantiate the storage
+                if target_file not in target_storage:
+                    # Ensure that the target file does not already exist
+                    if os.path.exists(target_path):
+                        raise RuntimeError(
+                            f"The target config file [{target_path}] already exists. " +
+                            "Should not."
+                        )
+
+                    # Instantiate the storage, which already creates the file
+                    target_storage[target_file] = Storage(filename=target_path)
+                    log("Target storage is loaded")
+                else:
+                    log("Target storage was already loaded")
+
+                # Bring the parameters from the old config
+                origin_value = copy.deepcopy(origin_file.get(origin_key))
+                log(f"Origin value for {origin_key} is loaded. We have a {type(origin_value)}")
+
+                # Could be that the target's parent objects were already created.
+                #   Check if they exist to avoid overwritting anything.
+                #   Still, if they don't exists, just go on creating the objects.
+                if target_key.find(".") > 0:
+                    target_key_pieces = target_key.split(".")
+                else:
+                    target_key_pieces = [target_key]
+                log(
+                    f"Target key {target_key} converted to pieces. " +
+                    f"We have {len(target_key_pieces)} pieces."
+                )
+                parents = ""
+                for piece in target_key_pieces:
+                    log(f"Starting with piece [{piece}]")
+                    # Get current target value
+                    current_target_value = target_storage[target_file].get(
+                        f"{parents}{piece}", None
+                    )
+                    is_none = " " if current_target_value is None else " NOT "
+                    log(f"The target piece [{parents}{piece}] is{is_none}None")
+
+                    # So if this object does not exist we have to create something.
+                    if current_target_value is None:
+                        # Are we actually the final object, suposed to hold ve target value?
+                        if piece == target_key_pieces[-1]:
+                            log(
+                                f"The target piece [{piece}] is the last on the target key " +
+                                f"[{target_key}]"
+                            )
+                            # Ok, so this is it, let's set the original value here
+                            target_storage[target_file].set(f"{parents}{piece}", origin_value)
+                            log(
+                                "The origin_value has been SET at target_storage[target_file] "
+                                + "in the key {parents}{piece}"
+                            )
+                        else:
+                            # No, it's not. We just set that this is an object and keep on going
+                            target_storage[target_file].set(f"{parents}{piece}", {})
+                            log(
+                                f"As the [{parents}{piece}] was not the last one and None, " +
+                                "only an empty dict is set here"
+                            )
                     else:
-                        # No, it's not. We just set that this is an object and keep on going
-                        target_storage[target_file].set(f"{parents}{piece}", {})
+                        # So there is anything here already.
+                        # We only write if it's actually the final object
+                        if piece == target_key_pieces[-1]:
+                            log(
+                                f"The target piece [{piece}] is the last on the target key " +
+                                f"[{target_key}]"
+                            )
+                            # Let's merge what we have here with what we bring.
+                            # The new data has preference
+                            new_value = {**current_target_value, **origin_value}
+                            target_storage[target_file].set(f"{parents}{piece}", new_value)
+                            log(
+                                "The origin_value has been MERGED at " +
+                                f"target_storage[target_file] in the key {parents}{piece}"
+                            )
 
-                # Update the parents path to the next child object
-                parents = f"{parents}{piece}."
+                    # Update the parents path to the next child object
+                    parents = f"{parents}{piece}."
 
-            # At this point, the value for the old parameter
-            #   and the value for the new parameter should match.
-            target_value = target_storage[target_file].get(target_key, None)
-            if origin_value != target_value:
-                raise ValueError(
-                    f"They copy from key {origin_key} into"
-                    f" {target_file}:{target_key} was unsuccessful"
-                )
+                # At this point, the value for the old parameter
+                #   and the value for the new parameter should match.
+                # ! THIS DOES NOT WORK IF WE DID MERGING!
+                # That's why we check only if the origin key/values exist in the
+                #   target space if it's an object, or the value only otherwise
+                target_value = target_storage[target_file].get(target_key, None)
+                if isinstance(origin_value, dict):
+                    log(f"Verifying that we copied the dict {origin_key} into {target_key}")
+                    for o_param, o_value in origin_value.items():
+                        log(f"Checking {o_param} key in destination, and comparing values")
+                        if o_param not in target_value or target_value[o_param] != o_value:
+                            raise ValueError(
+                                f"They copy from key {origin_key} into"
+                                f" {target_file}:{target_key} was unsuccessful,"
+                                f" missing {o_param} or it does not equals to {o_value}"
+                            )
+                elif origin_value != target_value:
+                    log(
+                        f"Verifying that we copied the value {origin_key}" +
+                        f" into {target_key} for a non-dict"
+                    )
+                    raise ValueError(
+                        f"They copy from key {origin_key} into"
+                        f" {target_file}:{target_key} was unsuccessful"
+                    )
 
         # At this point we only need to write what we hold in memory
         for file, storage_object in target_storage.items():
@@ -115,3 +210,9 @@ def run():
             )
     except Exception as e:
         print(f"{TerminalColor.RED_BRIGHT}{e}{TerminalColor.END}")
+
+
+def log(message: str):
+    if DEBUG:
+        message = f"{TerminalColor.BLUE}{message}{TerminalColor.END}"
+        print(message)

--- a/tests/lib/test_mastodon_helper.py
+++ b/tests/lib/test_mastodon_helper.py
@@ -7,17 +7,10 @@ import pytest
 from mastodon import Mastodon
 import os
 
-CONFIG = {
-    "logger.name": "logger_test",
-    "mastodon.named_accounts.default.instance_type": "mastodon",
-    "mastodon.named_accounts.default.credentials.user_file": "user.secret",
-    "mastodon.named_accounts.default.credentials.client_file": "client.secret",
-    "mastodon.named_accounts.default.api_base_url": "https://mastodont.cat",
-    "mastodon.named_accounts.default.credentials.user.email": "bot+syscheck@my-fancy.site",
-    "mastodon.named_accounts.default.credentials.user.password": "SuperSecureP4ss",
-}
+CONFIG = {"logger.name": "logger_test"}
 
 CONFIG_MASTODON_CONN_PARAMS = {
+    "app_type": "SuperApp",
     "instance_type": "mastodon",
     "api_base_url": "https://mastodont.cat",
     "credentials": {

--- a/tests/lib/test_mastodon_helper.py
+++ b/tests/lib/test_mastodon_helper.py
@@ -9,12 +9,12 @@ import os
 
 CONFIG = {
     "logger.name": "logger_test",
-    "mastodon.instance_type": "mastodon",
-    "mastodon.credentials.user_file": "user.secret",
-    "mastodon.credentials.client_file": "client.secret",
-    "mastodon.api_base_url": "https://mastodont.cat",
-    "mastodon.credentials.user.email": "bot+syscheck@my-fancy.site",
-    "mastodon.credentials.user.password": "SuperSecureP4ss",
+    "mastodon.per_name.default.instance_type": "mastodon",
+    "mastodon.per_name.default.credentials.user_file": "user.secret",
+    "mastodon.per_name.default.credentials.client_file": "client.secret",
+    "mastodon.per_name.default.api_base_url": "https://mastodont.cat",
+    "mastodon.per_name.default.credentials.user.email": "bot+syscheck@my-fancy.site",
+    "mastodon.per_name.default.credentials.user.password": "SuperSecureP4ss",
 }
 
 CONFIG_MASTODON_CONN_PARAMS = {

--- a/tests/lib/test_mastodon_helper.py
+++ b/tests/lib/test_mastodon_helper.py
@@ -9,12 +9,12 @@ import os
 
 CONFIG = {
     "logger.name": "logger_test",
-    "mastodon.per_name.default.instance_type": "mastodon",
-    "mastodon.per_name.default.credentials.user_file": "user.secret",
-    "mastodon.per_name.default.credentials.client_file": "client.secret",
-    "mastodon.per_name.default.api_base_url": "https://mastodont.cat",
-    "mastodon.per_name.default.credentials.user.email": "bot+syscheck@my-fancy.site",
-    "mastodon.per_name.default.credentials.user.password": "SuperSecureP4ss",
+    "mastodon.named_accounts.default.instance_type": "mastodon",
+    "mastodon.named_accounts.default.credentials.user_file": "user.secret",
+    "mastodon.named_accounts.default.credentials.client_file": "client.secret",
+    "mastodon.named_accounts.default.api_base_url": "https://mastodont.cat",
+    "mastodon.named_accounts.default.credentials.user.email": "bot+syscheck@my-fancy.site",
+    "mastodon.named_accounts.default.credentials.user.password": "SuperSecureP4ss",
 }
 
 CONFIG_MASTODON_CONN_PARAMS = {

--- a/tests/lib/test_publisher.py
+++ b/tests/lib/test_publisher.py
@@ -16,7 +16,7 @@ CONFIG = {
     "logger.name": "logger_test",
     "app.run_control.dry_run": False,
     "publisher.media_storage": "storage/media/",
-    "mastodon.per_name.default.instance_type": "mastodon"
+    "mastodon.named_accounts.default.instance_type": "mastodon"
 }
 
 _mocked_mastodon_instance: Mastodon = Mock()
@@ -122,7 +122,7 @@ def test_publish_one_not_dry_run_pleroma(queue_item_1: QueueItem):
     mocked_config_get.assert_has_calls(
         [
             call("app.run_control.dry_run"),
-            call("mastodon.per_name.default.instance_type", "mastodon"),
+            call("mastodon.named_accounts.default.instance_type", "mastodon"),
         ]
     )
     mocked_build_status_post.assert_called_once_with(queue_item_1.message)
@@ -158,7 +158,7 @@ def test_publish_one_not_dry_run_mastodon(queue_item_1: QueueItem):
     mocked_config_get.assert_has_calls(
         [
             call("app.run_control.dry_run"),
-            call("mastodon.per_name.default.instance_type", "mastodon"),
+            call("mastodon.named_accounts.default.instance_type", "mastodon"),
         ]
     )
     mocked_build_status_post.assert_called_once_with(queue_item_1.message)
@@ -192,7 +192,7 @@ def test_publish_one_not_dry_run_mastodon_cut_text(queue_item_long: QueueItem):
     mocked_config_get.assert_has_calls(
         [
             call("app.run_control.dry_run"),
-            call("mastodon.per_name.default.instance_type", "mastodon"),
+            call("mastodon.named_accounts.default.instance_type", "mastodon"),
         ]
     )
     mocked_build_status_post.assert_called_once_with(queue_item_long.message)

--- a/tests/lib/test_publisher.py
+++ b/tests/lib/test_publisher.py
@@ -16,7 +16,7 @@ CONFIG = {
     "logger.name": "logger_test",
     "app.run_control.dry_run": False,
     "publisher.media_storage": "storage/media/",
-    "mastodon.instance_type": "mastodon"
+    "mastodon.per_name.default.instance_type": "mastodon"
 }
 
 _mocked_mastodon_instance: Mastodon = Mock()
@@ -122,7 +122,7 @@ def test_publish_one_not_dry_run_pleroma(queue_item_1: QueueItem):
     mocked_config_get.assert_has_calls(
         [
             call("app.run_control.dry_run"),
-            call("mastodon.instance_type", "mastodon"),
+            call("mastodon.per_name.default.instance_type", "mastodon"),
         ]
     )
     mocked_build_status_post.assert_called_once_with(queue_item_1.message)
@@ -158,7 +158,7 @@ def test_publish_one_not_dry_run_mastodon(queue_item_1: QueueItem):
     mocked_config_get.assert_has_calls(
         [
             call("app.run_control.dry_run"),
-            call("mastodon.instance_type", "mastodon"),
+            call("mastodon.per_name.default.instance_type", "mastodon"),
         ]
     )
     mocked_build_status_post.assert_called_once_with(queue_item_1.message)
@@ -192,7 +192,7 @@ def test_publish_one_not_dry_run_mastodon_cut_text(queue_item_long: QueueItem):
     mocked_config_get.assert_has_calls(
         [
             call("app.run_control.dry_run"),
-            call("mastodon.instance_type", "mastodon"),
+            call("mastodon.per_name.default.instance_type", "mastodon"),
         ]
     )
     mocked_build_status_post.assert_called_once_with(queue_item_long.message)

--- a/tests/lib/test_publisher.py
+++ b/tests/lib/test_publisher.py
@@ -6,6 +6,7 @@ from janitor.lib.queue import Queue
 from janitor.objects.message import Message
 from janitor.objects.queue_item import QueueItem
 from janitor.objects.status_post import StatusPost
+from janitor.objects.mastodon_connection_params import MastodonConnectionParams
 from mastodon import Mastodon
 from unittest.mock import patch, Mock, call
 import pytest
@@ -15,8 +16,21 @@ from datetime import datetime
 CONFIG = {
     "logger.name": "logger_test",
     "app.run_control.dry_run": False,
-    "publisher.media_storage": "storage/media/",
-    "mastodon.named_accounts.default.instance_type": "mastodon"
+    "publisher.media_storage": "storage/media/"
+}
+
+CONFIG_MASTODON_CONN_PARAMS = {
+    "app_type": "SuperApp",
+    "instance_type": "mastodon",
+    "api_base_url": "https://mastodont.cat",
+    "credentials": {
+        "user_file": "user.secret",
+        "client_file": "client.secret",
+        "user": {
+            "email": "bot+syscheck@my-fancy.site",
+            "password": "SuperSecureP4ss",
+        }
+    }
 }
 
 _mocked_mastodon_instance: Mastodon = Mock()
@@ -35,7 +49,7 @@ def patched_generic_init(self, config: Config):
     pass
 
 
-def get_instance() -> Publisher:
+def get_instance(mastodon_connection_params: MastodonConnectionParams = None) -> Publisher:
     _mocked_mastodon_instance.__class__ = Mastodon
     _mocked_mastodon_instance.status_post = Mock()
     _mocked_mastodon_instance.status_post.return_value = {"id": 123}
@@ -43,12 +57,20 @@ def get_instance() -> Publisher:
     _mocked_mastodon_instance.media_post.return_value = {"id": 456}
     _mocked_queue_instance.return_value = None
 
+    if mastodon_connection_params is None:
+        mastodon_connection_params = MastodonConnectionParams.from_dict(
+            CONFIG_MASTODON_CONN_PARAMS
+        )
+
     with patch.object(Config, "__init__", new=patched_config_init):
         with patch.object(Config, "get", new=patched_config_get):
             with patch.object(Queue, "__init__", new=_mocked_queue_instance):
                 with patch.object(Formatter, "__init__", new=patched_generic_init):
                     return Publisher(
-                        config=Config(), mastodon=_mocked_mastodon_instance, base_path="bla"
+                        config=Config(),
+                        mastodon=_mocked_mastodon_instance,
+                        connection_params=mastodon_connection_params,
+                        base_path="bla"
                     )
 
 
@@ -109,22 +131,19 @@ def queue_item_long(datetime_2) -> QueueItem:
 
 def test_publish_one_not_dry_run_pleroma(queue_item_1: QueueItem):
     status_post = StatusPost(status=queue_item_1.message.text)
-    publisher = get_instance()
+    mastodon_connection_params = MastodonConnectionParams.from_dict(CONFIG_MASTODON_CONN_PARAMS)
+    mastodon_connection_params.instance_type = MastodonConnectionParams.TYPE_PLEROMA
+    publisher = get_instance(mastodon_connection_params=mastodon_connection_params)
 
     mocked_build_status_post = Mock()
     mocked_build_status_post.return_value = status_post
     mocked_config_get = Mock()
-    mocked_config_get.side_effect = [False, "pleroma", 500]
+    mocked_config_get.return_value = False
     with patch.object(Formatter, "build_status_post", new=mocked_build_status_post):
         with patch.object(Config, "get", new=mocked_config_get):
             result = publisher.publish_one(queue_item_1)
 
-    mocked_config_get.assert_has_calls(
-        [
-            call("app.run_control.dry_run"),
-            call("mastodon.named_accounts.default.instance_type", "mastodon"),
-        ]
-    )
+    mocked_config_get.assert_called_once_with("app.run_control.dry_run")
     mocked_build_status_post.assert_called_once_with(queue_item_1.message)
     _mocked_mastodon_instance.status_post.assert_called_once_with(
         status=status_post.status,
@@ -150,17 +169,12 @@ def test_publish_one_not_dry_run_mastodon(queue_item_1: QueueItem):
     mocked_build_status_post = Mock()
     mocked_build_status_post.return_value = status_post
     mocked_config_get = Mock()
-    mocked_config_get.side_effect = [False, "mastodon", 500]
+    mocked_config_get.return_value = False
     with patch.object(Formatter, "build_status_post", new=mocked_build_status_post):
         with patch.object(Config, "get", new=mocked_config_get):
             result = publisher.publish_one(queue_item_1)
 
-    mocked_config_get.assert_has_calls(
-        [
-            call("app.run_control.dry_run"),
-            call("mastodon.named_accounts.default.instance_type", "mastodon"),
-        ]
-    )
+    mocked_config_get.assert_called_once_with("app.run_control.dry_run")
     mocked_build_status_post.assert_called_once_with(queue_item_1.message)
     _mocked_mastodon_instance.status_post.assert_called_once_with(
         status=status_post.status,
@@ -184,17 +198,12 @@ def test_publish_one_not_dry_run_mastodon_cut_text(queue_item_long: QueueItem):
     mocked_build_status_post = Mock()
     mocked_build_status_post.return_value = status_post
     mocked_config_get = Mock()
-    mocked_config_get.side_effect = [False, "mastodon", 500]
+    mocked_config_get.return_value = False
     with patch.object(Formatter, "build_status_post", new=mocked_build_status_post):
         with patch.object(Config, "get", new=mocked_config_get):
             result = publisher.publish_one(queue_item_long)
 
-    mocked_config_get.assert_has_calls(
-        [
-            call("app.run_control.dry_run"),
-            call("mastodon.named_accounts.default.instance_type", "mastodon"),
-        ]
-    )
+    mocked_config_get.assert_called_once_with("app.run_control.dry_run")
     mocked_build_status_post.assert_called_once_with(queue_item_long.message)
     _mocked_mastodon_instance.status_post.assert_called_once_with(
         status=status_post.status[:497] + "...",

--- a/tests/lib/test_publisher.py
+++ b/tests/lib/test_publisher.py
@@ -6,7 +6,8 @@ from janitor.lib.queue import Queue
 from janitor.objects.message import Message
 from janitor.objects.queue_item import QueueItem
 from janitor.objects.status_post import StatusPost
-from janitor.objects.mastodon_connection_params import MastodonConnectionParams
+from janitor.objects.mastodon_connection_params import\
+    MastodonConnectionParams, MastodonStatusParams
 from mastodon import Mastodon
 from unittest.mock import patch, Mock, call
 import pytest
@@ -49,6 +50,10 @@ def patched_generic_init(self, config: Config):
     pass
 
 
+def patched_formatter_init(self, config: Config, status_params: MastodonStatusParams):
+    pass
+
+
 def get_instance(mastodon_connection_params: MastodonConnectionParams = None) -> Publisher:
     _mocked_mastodon_instance.__class__ = Mastodon
     _mocked_mastodon_instance.status_post = Mock()
@@ -65,7 +70,7 @@ def get_instance(mastodon_connection_params: MastodonConnectionParams = None) ->
     with patch.object(Config, "__init__", new=patched_config_init):
         with patch.object(Config, "get", new=patched_config_get):
             with patch.object(Queue, "__init__", new=_mocked_queue_instance):
-                with patch.object(Formatter, "__init__", new=patched_generic_init):
+                with patch.object(Formatter, "__init__", new=patched_formatter_init):
                     return Publisher(
                         config=Config(),
                         mastodon=_mocked_mastodon_instance,

--- a/tests/objects/test_mastodon_connection_params.py
+++ b/tests/objects/test_mastodon_connection_params.py
@@ -1,0 +1,273 @@
+from janitor.objects.mastodon_connection_params import\
+    MastodonConnectionParams, MastodonCredentials, MastodonUser, MastodonStatusParams
+from janitor.objects.status_post import StatusPostContentType, StatusPostVisibility
+from unittest import TestCase
+import pytest
+
+
+def test_instantiate_minimal():
+    instance = MastodonConnectionParams()
+
+    assert isinstance(instance, MastodonConnectionParams)
+
+
+def test_to_dict_minimal():
+    d = MastodonConnectionParams().to_dict()
+
+    assert d["instance_type"] is MastodonConnectionParams.TYPE_MASTODON
+    assert d["api_base_url"] is None
+    assert d["credentials"] is None
+    assert isinstance(d["status_params"], dict)
+    assert d["status_params"]["max_length"] == MastodonStatusParams.DEFAULT_MAX_LENGTH
+    assert d["status_params"]["content_type"] == MastodonStatusParams.DEFAULT_CONTENT_TYPE
+    assert d["status_params"]["visibility"] == MastodonStatusParams.DEFAULT_VISIBILITY
+    assert d["status_params"]["username_to_dm"] is None
+
+
+def test_from_dict_minimal():
+    instance = MastodonConnectionParams.from_dict({})
+
+    assert instance.instance_type == MastodonConnectionParams.TYPE_MASTODON
+    assert instance.api_base_url is None
+    assert instance.credentials is None
+    assert isinstance(instance.status_params, MastodonStatusParams)
+    assert instance.status_params.max_length == MastodonStatusParams.DEFAULT_MAX_LENGTH
+    assert instance.status_params.content_type == MastodonStatusParams.DEFAULT_CONTENT_TYPE
+    assert instance.status_params.visibility == MastodonStatusParams.DEFAULT_VISIBILITY
+    assert instance.status_params.username_to_dm is None
+
+
+def test_instantiate_with_instance_type():
+    instance = MastodonConnectionParams(instance_type=MastodonConnectionParams.TYPE_FIREFISH)
+
+    assert instance.instance_type == MastodonConnectionParams.TYPE_FIREFISH
+
+
+def test_instantiate_without_instace_type_defers_to_mastodon():
+    instance = MastodonConnectionParams()
+
+    assert instance.instance_type == MastodonConnectionParams.TYPE_MASTODON
+
+
+def test_instantiate_with_api_base_url():
+    test_api_base_url = "https://talamanca.social"
+
+    instance = MastodonConnectionParams(api_base_url=test_api_base_url)
+
+    assert instance.api_base_url == test_api_base_url
+
+
+def test_instantiate_with_credentials_defaults():
+    test_credentials = MastodonCredentials()
+    assert isinstance(test_credentials, MastodonCredentials)
+
+    instance = MastodonConnectionParams(credentials=test_credentials)
+
+    assert instance.credentials == test_credentials
+    assert instance.credentials.client_file == MastodonCredentials.DEFAULT_CLIENT_FILE
+    assert instance.credentials.user_file == MastodonCredentials.DEFAULT_USER_FILE
+    assert instance.credentials.user is None
+
+
+def test_instantiate_with_credentials_values():
+    test_client_file = "aaa"
+    test_user_file = "bbb"
+    test_credentials = MastodonCredentials.from_dict(
+        {
+            "client_file": test_client_file, "user_file": test_user_file
+        }
+    )
+    assert isinstance(test_credentials, MastodonCredentials)
+
+    instance = MastodonConnectionParams(credentials=test_credentials)
+
+    assert instance.credentials == test_credentials
+    assert instance.credentials.client_file == test_client_file
+    assert instance.credentials.user_file == test_user_file
+    assert instance.credentials.user is None
+
+    d = instance.credentials.to_dict()
+    assert d["client_file"] == test_client_file
+    assert d["user_file"] == test_user_file
+    assert d["user"] is None
+
+
+def test_instantiate_with_credentials_and_user_values():
+    test_user_email = "xavi@talamanca"
+    test_user_password = "pass"
+    test_credentials = MastodonCredentials.from_dict(
+        {"user": {
+            "email": test_user_email, "password": test_user_password
+        }}
+    )
+    assert isinstance(test_credentials, MastodonCredentials)
+    assert isinstance(test_credentials.user, MastodonUser)
+
+    instance = MastodonConnectionParams(credentials=test_credentials)
+
+    assert instance.credentials == test_credentials
+    assert instance.credentials.client_file == MastodonCredentials.DEFAULT_CLIENT_FILE
+    assert instance.credentials.user_file == MastodonCredentials.DEFAULT_USER_FILE
+    assert instance.credentials.user.email == test_user_email
+    assert instance.credentials.user.password == test_user_password
+
+    d = instance.credentials.to_dict()
+    assert d["user"]["email"] == test_user_email
+    assert d["user"]["password"] == test_user_password
+
+
+@pytest.mark.parametrize(
+    argnames=(
+        'max_length',
+        'content_type',
+        'visibility',
+        'username_to_dm',
+        'expected_length',
+        'expected_content_type',
+        'expected_visibility',
+        'expected_username_to_dm',
+        'expected_exception'
+    ),
+    argvalues=[
+        (
+            None,
+            None,
+            None,
+            None,
+            MastodonStatusParams.DEFAULT_MAX_LENGTH,
+            MastodonStatusParams.DEFAULT_CONTENT_TYPE,
+            MastodonStatusParams.DEFAULT_VISIBILITY,
+            None,
+            False
+        ),
+        (
+            400,
+            None,
+            None,
+            None,
+            400,
+            MastodonStatusParams.DEFAULT_CONTENT_TYPE,
+            MastodonStatusParams.DEFAULT_VISIBILITY,
+            None,
+            False
+        ),
+        (
+            None,
+            StatusPostContentType.MARKDOWN,
+            None,
+            None,
+            MastodonStatusParams.DEFAULT_MAX_LENGTH,
+            StatusPostContentType.MARKDOWN,
+            MastodonStatusParams.DEFAULT_VISIBILITY,
+            None,
+            False
+        ),
+        (
+            None,
+            "handwritten",
+            None,
+            None,
+            MastodonStatusParams.DEFAULT_MAX_LENGTH,
+            None,
+            MastodonStatusParams.DEFAULT_VISIBILITY,
+            None, (StatusPostContentType, RuntimeError)
+        ),
+        (
+            None,
+            None,
+            StatusPostVisibility.PRIVATE,
+            None,
+            MastodonStatusParams.DEFAULT_MAX_LENGTH,
+            MastodonStatusParams.DEFAULT_CONTENT_TYPE,
+            StatusPostVisibility.PRIVATE,
+            None,
+            False
+        ),
+        (
+            None,
+            None,
+            "invisible",
+            None,
+            MastodonStatusParams.DEFAULT_MAX_LENGTH,
+            MastodonStatusParams.DEFAULT_CONTENT_TYPE,
+            None,
+            None, (StatusPostVisibility, RuntimeError)
+        ),
+        (
+            None,
+            None,
+            StatusPostVisibility.DIRECT,
+            None,
+            MastodonStatusParams.DEFAULT_MAX_LENGTH,
+            MastodonStatusParams.DEFAULT_CONTENT_TYPE,
+            None,
+            None, (MastodonStatusParams, ValueError)
+        ),
+        (
+            None,
+            None,
+            StatusPostVisibility.DIRECT,
+            "@user",
+            MastodonStatusParams.DEFAULT_MAX_LENGTH,
+            MastodonStatusParams.DEFAULT_CONTENT_TYPE,
+            StatusPostVisibility.DIRECT,
+            "@user",
+            False
+        ),
+    ],
+)
+def test_instantiate_with_status_post_with_values(
+    max_length,
+    content_type,
+    visibility,
+    username_to_dm,
+    expected_length,
+    expected_content_type,
+    expected_visibility,
+    expected_username_to_dm,
+    expected_exception
+):
+    if expected_exception:
+        who, what = expected_exception
+        with TestCase.assertRaises(who, what):
+            _ = MastodonStatusParams(
+                max_length=max_length,
+                content_type=content_type,
+                visibility=visibility,
+                username_to_dm=username_to_dm
+            )
+    else:
+        status_params = MastodonStatusParams(
+            max_length=max_length,
+            content_type=content_type,
+            visibility=visibility,
+            username_to_dm=username_to_dm
+        )
+
+        assert status_params.max_length == expected_length
+        assert status_params.content_type == expected_content_type
+        assert status_params.visibility == expected_visibility
+        assert status_params.username_to_dm == expected_username_to_dm
+
+        instance = MastodonConnectionParams.from_dict(
+            {
+                "status_params": {
+                    "max_length": max_length,
+                    "content_type": content_type,
+                    "visibility": visibility,
+                    "username_to_dm": username_to_dm,
+                }
+            }
+        )
+
+        assert instance.status_params.max_length == expected_length
+        assert instance.status_params.content_type == expected_content_type
+        assert instance.status_params.visibility == expected_visibility
+        assert instance.status_params.username_to_dm == expected_username_to_dm
+
+        d = instance.to_dict()
+
+        assert d["status_params"]["max_length"] == expected_length
+        assert d["status_params"]["content_type"] == expected_content_type
+        assert d["status_params"]["visibility"] == expected_visibility
+        assert d["status_params"]["username_to_dm"] == expected_username_to_dm

--- a/tests/objects/test_mastodon_connection_params.py
+++ b/tests/objects/test_mastodon_connection_params.py
@@ -14,7 +14,8 @@ def test_instantiate_minimal():
 def test_to_dict_minimal():
     d = MastodonConnectionParams().to_dict()
 
-    assert d["instance_type"] is MastodonConnectionParams.TYPE_MASTODON
+    assert d["app_name"] is None
+    assert d["instance_type"] == MastodonConnectionParams.TYPE_MASTODON
     assert d["api_base_url"] is None
     assert d["credentials"] is None
     assert isinstance(d["status_params"], dict)
@@ -27,6 +28,7 @@ def test_to_dict_minimal():
 def test_from_dict_minimal():
     instance = MastodonConnectionParams.from_dict({})
 
+    assert instance.app_name == None
     assert instance.instance_type == MastodonConnectionParams.TYPE_MASTODON
     assert instance.api_base_url is None
     assert instance.credentials is None
@@ -35,6 +37,13 @@ def test_from_dict_minimal():
     assert instance.status_params.content_type == MastodonStatusParams.DEFAULT_CONTENT_TYPE
     assert instance.status_params.visibility == MastodonStatusParams.DEFAULT_VISIBILITY
     assert instance.status_params.username_to_dm is None
+
+
+def test_instantiate_with_app_name():
+    test_app_name = "hola"
+    instance = MastodonConnectionParams(app_name=test_app_name)
+
+    assert instance.app_name == test_app_name
 
 
 def test_instantiate_with_instance_type():

--- a/tests/objects/test_mastodon_connection_params.py
+++ b/tests/objects/test_mastodon_connection_params.py
@@ -28,7 +28,7 @@ def test_to_dict_minimal():
 def test_from_dict_minimal():
     instance = MastodonConnectionParams.from_dict({})
 
-    assert instance.app_name == None
+    assert instance.app_name is None
     assert instance.instance_type == MastodonConnectionParams.TYPE_MASTODON
     assert instance.api_base_url is None
     assert instance.credentials is None

--- a/tests/runners/test_create_app.py
+++ b/tests/runners/test_create_app.py
@@ -62,9 +62,9 @@ def test_create_app():
     )
     mocked_config_get.assert_has_calls(
         [
-            call("mastodon.instance_type"),
-            call("mastodon.app_name"),
-            call("mastodon.api_base_url"),
-            call("mastodon.credentials.client_file"),
+            call("mastodon.per_name.default.instance_type"),
+            call("mastodon.per_name.default.app_name"),
+            call("mastodon.per_name.default.api_base_url"),
+            call("mastodon.per_name.default.credentials.client_file"),
         ]
     )

--- a/tests/runners/test_create_app.py
+++ b/tests/runners/test_create_app.py
@@ -62,9 +62,9 @@ def test_create_app():
     )
     mocked_config_get.assert_has_calls(
         [
-            call("mastodon.per_name.default.instance_type"),
-            call("mastodon.per_name.default.app_name"),
-            call("mastodon.per_name.default.api_base_url"),
-            call("mastodon.per_name.default.credentials.client_file"),
+            call("mastodon.named_accounts.default.instance_type"),
+            call("mastodon.named_accounts.default.app_name"),
+            call("mastodon.named_accounts.default.api_base_url"),
+            call("mastodon.named_accounts.default.credentials.client_file"),
         ]
     )

--- a/tests/runners/test_run_listen.py
+++ b/tests/runners/test_run_listen.py
@@ -33,6 +33,20 @@ COLLECTED_DATA = {
     }
 }
 
+CONFIG_MASTODON_CONN_PARAMS = {
+    "app_type": "SuperApp",
+    "instance_type": "mastodon",
+    "api_base_url": "https://mastodont.cat",
+    "credentials": {
+        "user_file": "user.secret",
+        "client_file": "client.secret",
+        "user": {
+            "email": "bot+syscheck@my-fancy.site",
+            "password": "SuperSecureP4ss",
+        }
+    }
+}
+
 ICONS = {
     MessageType.NONE: "",
     MessageType.INFO: "1",
@@ -78,7 +92,12 @@ def patched_generic_init_with_config(self, config):
     pass
 
 
-def patched_mastodon_get_instance(config, base_path):
+def patched_config_get(self, param):
+    if param == "mastodon.named_accounts.default":
+        return CONFIG_MASTODON_CONN_PARAMS
+
+
+def patched_mastodon_get_instance(config, connection_params, base_path):
     pass
 
 
@@ -154,6 +173,7 @@ def test_post_data_comes_in_post_no_crossed_thresholds(collected_data):
 @patch.object(reqparse.RequestParser, "add_argument", new=patched_parser_add_argument)
 @patch.object(SystemInfoTemplater, "__init__", new=patched_generic_init_with_config)
 @patch.object(MastodonHelper, "get_instance", new=patched_mastodon_get_instance)
+@patch.object(Config, "get", new=patched_config_get)
 @patch.object(Publisher, "__init__", new=patched_publisher_init)
 def test_post_data_comes_in_post_crossed_thresholds(collected_data):
     message = Message(text="content of the report")
@@ -277,6 +297,7 @@ def test_init_message():
 @patch.object(reqparse.RequestParser, "add_argument", new=patched_parser_add_argument)
 @patch.object(MastodonHelper, "get_instance", new=patched_mastodon_get_instance)
 @patch.object(Publisher, "__init__", new=patched_publisher_init)
+@patch.object(Config, "get", new=patched_config_get)
 def test_post_optional_params_not_present(
     summary,
     text,

--- a/tests/runners/test_run_listen.py
+++ b/tests/runners/test_run_listen.py
@@ -101,7 +101,7 @@ def patched_mastodon_get_instance(config, connection_params, base_path):
     pass
 
 
-def patched_publisher_init(self, config, mastodon, base_path):
+def patched_publisher_init(self, config, mastodon, connection_params, base_path):
     pass
 
 

--- a/tests/runners/test_run_local.py
+++ b/tests/runners/test_run_local.py
@@ -32,6 +32,20 @@ COLLECTED_DATA = {
     }
 }
 
+CONFIG_MASTODON_CONN_PARAMS = {
+    "app_type": "SuperApp",
+    "instance_type": "mastodon",
+    "api_base_url": "https://mastodont.cat",
+    "credentials": {
+        "user_file": "user.secret",
+        "client_file": "client.secret",
+        "user": {
+            "email": "bot+syscheck@my-fancy.site",
+            "password": "SuperSecureP4ss",
+        }
+    }
+}
+
 
 def patched_get_hostname(self):
     return COLLECTED_DATA["hostname"]
@@ -65,11 +79,16 @@ def patched_generic_init(self):
     pass
 
 
+def patched_config_get(self, param):
+    if param == "mastodon.named_accounts.default":
+        return CONFIG_MASTODON_CONN_PARAMS
+
+
 def patched_generic_init_with_config(self, config):
     pass
 
 
-def patched_mastodon_get_instance(config, base_path):
+def patched_mastodon_get_instance(config, connection_params, base_path):
     pass
 
 
@@ -120,6 +139,7 @@ def test_run_no_crossed_thresholds():
 @patch.object(SystemInfoTemplater, "__init__", new=patched_generic_init_with_config)
 @patch.object(MastodonHelper, "get_instance", new=patched_mastodon_get_instance)
 @patch.object(Publisher, "__init__", new=patched_publisher_init)
+@patch.object(Config, "get", new=patched_config_get)
 def test_run_crossed_thresholds(collected_data):
     message = Message(text="content of the report")
 

--- a/tests/runners/test_run_local.py
+++ b/tests/runners/test_run_local.py
@@ -92,7 +92,7 @@ def patched_mastodon_get_instance(config, connection_params, base_path):
     pass
 
 
-def patched_publisher_init(self, config, mastodon, base_path):
+def patched_publisher_init(self, config, mastodon, connection_params, base_path):
     pass
 
 


### PR DESCRIPTION
✅ Move config param `git_monitor.mastodon.*` into `mastodon` file, with a `named_accounts` and `default` setup
✅ Adapt code and test
✅ Update code (& tests) so that `MastodonHelper` only works with the received `MastodonConnectionParams`
✅ Make the `status_post` parameters to be per named account.
✅  Adapt `migrate_config` script
* Update documentation