### PR TITLE
Add ability to rotate logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - A new CLI command (the main runner) to return the current external address ([#29](https://github.com/XaviArnaus/janitor/pull/29))
 - New CLI arguments to override logging config and print it to stdout ([#29](https://github.com/XaviArnaus/janitor/pull/29))
+- A new CLI and Scheduler command to rotate the log file ([#30](https://github.com/XaviArnaus/janitor/pull/30))
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@
 - Make the `git_monitor` to monitor git tags and not only CHANGELOG changes.
 - Make a PyPI monitor
 - When the Listener starts, loop the status until it gets up and running.
-- Rotate the logs
 
 # Done
 
@@ -30,3 +29,4 @@
     ➡️ Won't do, as obscures the tasks to do and now we have a tool to start/stop/status the Listener
 ✅ Make the `git_monitor` to be able to publish to several other Mastodon accounts (example: own repositories vs. external repositories)
 ✅ A command to request for the external IP, reusing the logic we already have
+✅ Rotate the logs

--- a/config/schedules.yaml.dist
+++ b/config/schedules.yaml.dist
@@ -10,5 +10,5 @@ schedules:
   - name: "Heartbeat"
     # crontab format: minute hour day-of-month month day-of-week
     when: "* * * * *"
-    # [String] possible values: "sysinfo_local" | "sysinfo_remote" | "update_ddns" | "publish_git_changes"
+    # [String] possible values: "sysinfo_local" | "sysinfo_remote" | "update_ddns" | "publish_git_changes" | "rotate_log"
     action: "sysinfo_local"

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -64,3 +64,4 @@ At the moment, the following actions are allowed:
 - `sysinfo_remote`: Gathers the local System Info and sends them to a listening server to be processed
 - `update_ddns`: Discovers the current external IP and updates the Directnic Dynamic DNS registers
 - `git_changes`: Discovers changes in the monitored Git repositories and publishes them
+- `rotate_log`: Renames the current log file to a timestamped filename so that a new one is created.

--- a/janitor/runners/log_rotate.py
+++ b/janitor/runners/log_rotate.py
@@ -1,0 +1,37 @@
+from pyxavi.config import Config
+from janitor.runners.runner_protocol import RunnerProtocol
+import logging
+from datetime import datetime
+import os
+
+ROTATED_DATETIME = "%Y%m%d%H%I%S"
+
+
+class LogRotate(RunnerProtocol):
+    '''
+    Runner that rotates the log file
+    '''
+
+    def __init__(self, config: Config = None, logger: logging = None) -> None:
+        self._config = config
+        self._logger = logger
+
+    def run(self):
+        '''
+        Reads the current log filename and moves it to a rotated one.
+        '''
+        self._logger.debug("Rotating the logs")
+        # So the strategy is the following:
+        #   1. Rename the current log file to f"{current_log_file.log}.old-{datetime}"
+        #   2. The logging system will create automatically the new f"{current_log_file.log}"
+
+        current_log_file = self._config.get("logger.filename")
+        if current_log_file is None:
+            raise RuntimeError(
+                "Could not get the current log filename. Do you have it in the config file?"
+            )
+        now = datetime.now().strftime(ROTATED_DATETIME)
+        new_log_file_name = f"{current_log_file}.old-{now}"
+        self._logger.debug(f"Will rotate the log {current_log_file} to {new_log_file_name}")
+        os.rename(current_log_file, new_log_file_name)
+        self._logger.info(f"Log rotate {current_log_file} to {new_log_file_name}")

--- a/janitor/runners/scheduler.py
+++ b/janitor/runners/scheduler.py
@@ -8,6 +8,7 @@ from janitor.runners.run_local import RunLocal
 from janitor.runners.run_remote import RunRemote
 from janitor.runners.update_ddns import UpdateDdns
 from janitor.runners.git_changes import GitChanges
+from janitor.runners.log_rotate import LogRotate
 
 
 class Scheduler(RunnerProtocol):
@@ -44,3 +45,5 @@ class Scheduler(RunnerProtocol):
             UpdateDdns(config=self._config, logger=self._logger).run()
         elif action == "git_changes":
             GitChanges(config=self._config, logger=self._logger).run()
+        elif action == "rotate_log":
+            LogRotate(config=self._config, logger=self._logger).run()

--- a/runner.py
+++ b/runner.py
@@ -21,6 +21,7 @@ from janitor.runners.publish_test import PublishTest
 from janitor.runners.update_ddns import UpdateDdns
 from janitor.runners.git_changes import GitChanges
 from janitor.runners.whatismyip import WhatIsMyIp
+from janitor.runners.log_rotate import LogRotate
 
 PROGRAM_NAME = "janitor"
 CLI_NAME = "jan"
@@ -54,6 +55,7 @@ COMMAND_MAP = {
     ),
     "migrate_config": (SUBCOMMAND_TOKEN, "Migrates the configuration file(s) between versions"),
     "ip": (WhatIsMyIp, "Returns the current external IP"),
+    "rotate_log": (LogRotate, "Rotate the log file"),
 }
 
 SUBCOMMAND_MAP = {


### PR DESCRIPTION
With such an amount of tasks and periodic executions, the logs fill pretty soon. This introduces a first iteration where the log file is renamed for archiving.

There has to be a follow up to clean files that are too old.