### PR TITLE
Fix first run with new config and test_message failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 - Make Flask to log above WARNING ([#38](https://github.com/XaviArnaus/janitor/pull/38))
 - Show who is sending a request to the Listener ([#38](https://github.com/XaviArnaus/janitor/pull/38))
 
+### Fixed
+
+- Fix a wrong param name in `mastodon.yaml.dist` ([#39](https://github.com/XaviArnaus/janitor/pull/39))
+- Fix a bug that made fail the `bin/jan mastodon test` command ([#39](https://github.com/XaviArnaus/janitor/pull/39))
+
 ## [v0.5.1](https://github.com/XaviArnaus/janitor/releases/tag/v0.5.1)
 
 ### Added

--- a/config/mastodon.yaml.dist
+++ b/config/mastodon.yaml.dist
@@ -35,7 +35,7 @@ mastodon:
           # [String] Password to be used to log in. For instance_type "firefish" it is the Bearer token.
           password: "SuperSecureP4ss"
       # Configuration regarding the Status Post itself
-      status_post:
+      status_params:
         # [Integer] Status max length
         max_length: 500
         # [String] Status Post content type: "text/plain" | "text/markdown" | "text/html" | "text/bbcode"

--- a/janitor/runners/publish_test.py
+++ b/janitor/runners/publish_test.py
@@ -31,7 +31,7 @@ class PublishTest(RunnerProtocol):
         for account in preferred_named_accounts:
             account_defined = self._config.get(f"mastodon.named_accounts.{account}", None)
             if account_defined is not None:
-                named_account = account_defined
+                named_account = account
                 break
 
         if named_account is None:
@@ -40,7 +40,7 @@ class PublishTest(RunnerProtocol):
                 preferred_named_accounts
             )
         else:
-            self._logger.debug(f"Will publish to {named_account['app_name']}")
+            self._logger.debug(f"Will publish to {named_account}")
             params["named_account"] = named_account
             self._params = params
 


### PR DESCRIPTION
The first run, when one sets up the app from scratch and copies the distributed `mastodon.yaml` config, the `bin/jan mastodon test` fails due few points.